### PR TITLE
fix: correct timeout for supplied context

### DIFF
--- a/waiter.go
+++ b/waiter.go
@@ -136,10 +136,9 @@ func (o options) contextWithCancel() (context.Context, func()) {
 
 	if ctx == nil {
 		ctx = context.Background()
-
-		if o.timeout > 0 {
-			ctx, cancel = context.WithTimeout(ctx, o.timeout)
-		}
+	}
+	if o.timeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, o.timeout)
 	}
 
 	return ctx, cancel


### PR DESCRIPTION
The original implementation contained a bug that meant that the timeout would not be applied if `WithContext` was supplied as an option. This meant that if the provided context did not have a cancellation then the `Waiter` would wait indefinitely.

This PR corrects the default behaviour. Indefinite waits can still be achieved by not provided a context with cancellation and using `WithTimeout(0)`, although I can't see any scenarios where this would be valuable.