### PR TITLE
feat: simplify checks to not require info

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ err := healthy.New(
 ```
 
 ## Checks
-Healthy includes checks for TCP, HTTP and files. Additional checks can be added by implementing `healthy.Check`. Alternatively `healthy.NewCheck` returns a new check using a supplied `CheckFunc` and information:
+Healthy includes checks for TCP, HTTP and files. Additional checks can be added by implementing `healthy.Check` or providing a `healthy.CheckFunc`. Additional information can be added to the check using either `healthy.NewCheck` or implementing `healthy.InfoCheck`. This is passed to the callback func if registered and would typically be used for logging (see example below).
 ```
 c := healthy.NewCheck(func(ctx context.Context) error {
     // implement check

--- a/check.go
+++ b/check.go
@@ -9,6 +9,10 @@ import (
 type (
 	Check interface {
 		Healthy(ctx context.Context) error
+	}
+
+	InfoCheck interface {
+		Check
 		Info() Info
 	}
 
@@ -33,7 +37,7 @@ type (
 	}
 )
 
-func NewCheck(fn CheckFunc, info ...string) Check {
+func NewCheck(fn CheckFunc, info ...string) InfoCheck {
 	if fn == nil {
 		panic("fn must not be nil")
 	}
@@ -51,6 +55,10 @@ func NewCheck(fn CheckFunc, info ...string) Check {
 	}
 
 	return c
+}
+
+func (c CheckFunc) Healthy(ctx context.Context) error {
+	return c(ctx)
 }
 
 func (c *check) Healthy(ctx context.Context) error {

--- a/check_file.go
+++ b/check_file.go
@@ -5,7 +5,7 @@ import (
 	"os"
 )
 
-func File(path string) Check {
+func File(path string) InfoCheck {
 	return NewCheck(func(ctx context.Context) error {
 		_, err := os.Stat(path)
 		return err

--- a/waiter.go
+++ b/waiter.go
@@ -59,7 +59,11 @@ func (w *Waiter) Wait(opts ...Option) error {
 	for _, cc := range w.checks {
 		g.Go(func() error {
 			attempt := 1
-			info := maps.Clone(cc.Info())
+
+			var info Info
+			if ic, ok := cc.(InfoCheck); ok {
+				info = maps.Clone(ic.Info())
+			}
 
 			for {
 				err := cc.Healthy(ctx)

--- a/waiter_test.go
+++ b/waiter_test.go
@@ -33,7 +33,7 @@ func TestExecutor_Wait(t *testing.T) {
 	})
 
 	t.Run("should abort on fatal error", func(t *testing.T) {
-		err := healthy.New(healthy.NewCheck(func(ctx context.Context) error {
+		err := healthy.New(healthy.CheckFunc(func(ctx context.Context) error {
 			return healthy.Fatal(errors.New("fatal"))
 		})).Wait()
 		if !healthy.IsFatal(err) {
@@ -59,7 +59,7 @@ func TestExecutor_Wait(t *testing.T) {
 	t.Run("should wait for check", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			var n int32
-			err := healthy.New(healthy.NewCheck(func(ctx context.Context) error {
+			err := healthy.New(healthy.CheckFunc(func(ctx context.Context) error {
 				if atomic.LoadInt32(&n) < 1 {
 					return errors.New("error")
 				}
@@ -79,7 +79,7 @@ func TestExecutor_Wait(t *testing.T) {
 }
 
 func TestWithContext(t *testing.T) {
-	sut := healthy.New(healthy.NewCheck(func(ctx context.Context) error {
+	sut := healthy.New(healthy.CheckFunc(func(ctx context.Context) error {
 		return errors.New("error")
 	}))
 


### PR DESCRIPTION
The first implementation accepted a `healthy.CheckFunc` in calls to `Wait` which made adding simple checks trivial. However, the addition of check information that could be provided to callbacks complicated the interface, requiring calls to `healthy.NewCheck` and the wrapping of each `CheckFunc`.

This PR restores the simpler initial approach, effectively making the check information optional (as it already is via `NewCheck`). There isn't a tangible difference in behaviour or performance, but the API should make more natural sense for the majority of use cases.