### PR TITLE
test: add zero timeout test

### DIFF
--- a/waiter_test.go
+++ b/waiter_test.go
@@ -102,6 +102,17 @@ func TestWithContext(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("should accept zero timeout", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			err := sut.Wait(healthy.WithContext(ctx), healthy.WithTimeout(0)) // use supplied context to control timeout
+			if err == nil {
+				t.Error("got nil, expected error")
+			}
+		})
+	})
 }
 
 func TestWithCallback(t *testing.T) {


### PR DESCRIPTION
While the default timeout for calls to `Wait` is 30 seconds, it is possible to override this with a zero value to either defer timeout/cancellation to a context supplied by `WithContext` or to allow for indefinite waiting.

There isn't really a strong use case for either of the above, but this PR adds a test to demonstrate that option (and let's be honest, gets the repo back to 100% coverage).