### PR TITLE
Minor updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,19 +54,18 @@ The initial implementation of the module allowed multiple checks to be executed 
 If parallel check execution is desired, then it is trivial (if a bit more verbose) to execute them using `errgroup`:
 ```
 g, ctx := errgroup.WithContext(context.Background())
+
+opts := healthy.JoinOptions(
+    healthy.WithContext(ctx),
+    healthy.WithCallback(callback),
+)
+
 g.Go(func() error {
-    return healthy.Wait(
-        healthy.TCP("host:8080"),
-        healthy.WithContext(ctx),
-        healthy.WithCallback(callback),
-    )
+    return healthy.Wait(healthy.TCP("host:8080"), opts)
 })
 g.Go(func() error {
-    return healthy.Wait(
-        healthy.HTTP("http://dependency:8080/health"),
-        healthy.WithContext(ctx),
-        healthy.WithCallback(callback),
-    )
+    return healthy.Wait(healthy.HTTP("http://dependency:8080/health"), opts)
 })
-err = g.Wait()
+
+err := g.Wait()
 ```

--- a/check.go
+++ b/check.go
@@ -5,16 +5,16 @@ import (
 )
 
 type (
-	// Check represents a health check
+	// Check represents a health check.
 	Check interface {
 		Healthy(ctx context.Context) error
 	}
 
-	// CheckFunc represents a health check function
+	// CheckFunc represents a health check function.
 	CheckFunc func(ctx context.Context) error
 )
 
-// Healthy should return nil if the health check is successful
+// Healthy should return nil if the health check is successful.
 func (c CheckFunc) Healthy(ctx context.Context) error {
 	return c(ctx)
 }

--- a/check_file.go
+++ b/check_file.go
@@ -5,7 +5,7 @@ import (
 	"os"
 )
 
-// File returns a file health check
+// File returns a file health check.
 // The check returns nil if the file exists.
 func File(path string) MetadataCheck {
 	return WithMetadata(func(ctx context.Context) error {

--- a/check_file_test.go
+++ b/check_file_test.go
@@ -44,8 +44,8 @@ func TestFile_Check(t *testing.T) {
 	})
 }
 
-func TestFile_Info(t *testing.T) {
-	t.Run("should return the check info", func(t *testing.T) {
+func TestFile_Metadata(t *testing.T) {
+	t.Run("should return the check metadata", func(t *testing.T) {
 		const file = "test.txt"
 		exp := healthy.Metadata{"type": "file", "target": file}
 		act := healthy.File(file).Metadata()

--- a/check_http.go
+++ b/check_http.go
@@ -7,14 +7,14 @@ import (
 	"time"
 )
 
-// HTTPCheck represents an HTTP health check
+// HTTPCheck represents an HTTP health check.
 type HTTPCheck struct {
 	client     *http.Client
 	url        string
 	statusCode int
 }
 
-// HTTP returns an HTTP health check
+// HTTP returns an HTTP health check.
 func HTTP(url string) *HTTPCheck {
 	return &HTTPCheck{
 		client:     &http.Client{Timeout: time.Second},
@@ -23,19 +23,19 @@ func HTTP(url string) *HTTPCheck {
 	}
 }
 
-// Timout specifies the HTTP client timeout
+// Timout specifies the HTTP client timeout.
 func (c *HTTPCheck) Timeout(t time.Duration) *HTTPCheck {
 	c.client.Timeout = t
 	return c
 }
 
-// Expect specifies the expected status code
+// Expect specifies the expected status code.
 func (c *HTTPCheck) Expect(statusCode int) *HTTPCheck {
 	c.statusCode = statusCode
 	return c
 }
 
-// Healthy returns true if the target URL returns the expected status code
+// Healthy returns true if the target URL returns the expected status code.
 func (c *HTTPCheck) Healthy(ctx context.Context) error {
 	req, err := http.NewRequest(http.MethodGet, c.url, nil)
 	if err != nil {
@@ -54,7 +54,7 @@ func (c *HTTPCheck) Healthy(ctx context.Context) error {
 	return nil
 }
 
-// Metadata returns the check metadata
+// Metadata returns the check metadata.
 func (c *HTTPCheck) Metadata() Metadata {
 	return Metadata{
 		"type":    "http",

--- a/check_http_test.go
+++ b/check_http_test.go
@@ -56,7 +56,7 @@ func TestHTTPCheck_Healthy(t *testing.T) {
 }
 
 func TestHTTP_Metadata(t *testing.T) {
-	t.Run("should return the check info", func(t *testing.T) {
+	t.Run("should return the check metadata", func(t *testing.T) {
 		const target = "http://localhost:8080s"
 		exp := healthy.Metadata{"type": "http", "target": target, "timeout": "500ms"}
 		act := healthy.HTTP(target).Timeout(500 * time.Millisecond).Metadata()

--- a/check_tcp.go
+++ b/check_tcp.go
@@ -6,13 +6,13 @@ import (
 	"time"
 )
 
-// TCPCheck represents a TCP health check
+// TCPCheck represents a TCP health check.
 type TCPCheck struct {
 	addr    string
 	timeout time.Duration
 }
 
-// TCP returns a TCP health check
+// TCP returns a TCP health check.
 func TCP(addr string) *TCPCheck {
 	return &TCPCheck{
 		addr:    addr,
@@ -27,7 +27,7 @@ func (c *TCPCheck) Timeout(t time.Duration) *TCPCheck {
 }
 
 // Healtyh returns nil if a TCP connection can be established with
-// the target address
+// the target address.
 func (c *TCPCheck) Healthy(ctx context.Context) error {
 	conn, err := net.DialTimeout("tcp", c.addr, c.timeout)
 	if err != nil {
@@ -38,7 +38,7 @@ func (c *TCPCheck) Healthy(ctx context.Context) error {
 	return nil
 }
 
-// Metadata retuns the check metadata
+// Metadata retuns the check metadata.
 func (c *TCPCheck) Metadata() Metadata {
 	return Metadata{
 		"type":    "tcp",

--- a/check_tcp_test.go
+++ b/check_tcp_test.go
@@ -37,8 +37,8 @@ func TestTCPCheck_Healthy(t *testing.T) {
 	})
 }
 
-func TestTCP_Info(t *testing.T) {
-	t.Run("should return the check info", func(t *testing.T) {
+func TestTCP_Metadata(t *testing.T) {
+	t.Run("should return the check metadata", func(t *testing.T) {
 		const target = "localhost:8080"
 		exp := healthy.Metadata{"type": "tcp", "target": target, "timeout": "500ms"}
 		act := healthy.TCP(target).Timeout(500 * time.Millisecond).Metadata()

--- a/error.go
+++ b/error.go
@@ -6,24 +6,24 @@ type fatalError struct {
 	err error
 }
 
-// Fatal wraps the supplied error to indicate that it is fatal
+// Fatal wraps the supplied error to indicate that it is fatal.
 // When a check returns a fatal error retry execution will be aborted.
 func Fatal(err error) error {
 	return &fatalError{err: err}
 }
 
-// IsFatal returns true if the supplied error is fatal
+// IsFatal returns true if the supplied error is fatal.
 func IsFatal(err error) bool {
 	var f *fatalError
 	return errors.As(err, &f)
 }
 
-// Error returns the inner error message
+// Error returns the inner error message.
 func (e *fatalError) Error() string {
 	return e.err.Error()
 }
 
-// Unwrap returns the inner error
+// Unwrap returns the inner error.
 func (e *fatalError) Unwrap() []error {
 	return []error{e.err}
 }

--- a/error.go
+++ b/error.go
@@ -24,6 +24,6 @@ func (e *fatalError) Error() string {
 }
 
 // Unwrap returns the inner error.
-func (e *fatalError) Unwrap() []error {
-	return []error{e.err}
+func (e *fatalError) Unwrap() error {
+	return e.err
 }

--- a/error_test.go
+++ b/error_test.go
@@ -29,9 +29,9 @@ func TestFatalError_Error(t *testing.T) {
 func TestFatalError_Unwrap(t *testing.T) {
 	t.Run("should return the inner error", func(t *testing.T) {
 		exp := errors.New("error")
-		act := healthy.Fatal(exp).(interface{ Unwrap() []error }).Unwrap()
-		if act[0] != exp {
-			t.Errorf("got %v, expected %v", act[0], exp)
+		act := healthy.Fatal(exp).(interface{ Unwrap() error }).Unwrap()
+		if act != exp {
+			t.Errorf("got %v, expected %v", act, exp)
 		}
 	})
 }

--- a/example_test.go
+++ b/example_test.go
@@ -19,7 +19,7 @@ func ExampleNew() {
 		healthy.HTTP(url).Timeout(time.Millisecond).Expect(http.StatusOK),
 		healthy.WithTimeout(time.Second),
 		healthy.WithDelay(10*time.Millisecond),
-		healthy.WithJitter(0),
+		healthy.WithJitter(10*time.Millisecond),
 	)
 
 	fmt.Println(err)

--- a/healthy.go
+++ b/healthy.go
@@ -10,7 +10,7 @@ import (
 )
 
 type (
-	// Option represents an execution option
+	// Option represents an execution option.
 	Option func(*options)
 
 	options struct {
@@ -21,7 +21,7 @@ type (
 		callback CallbackFunc
 	}
 
-	// CallbackFunc represents an execution callback function
+	// CallbackFunc represents an execution callback function.
 	// The function is invoked on each health check invocation.
 	CallbackFunc func(ctx context.Context, err error)
 )
@@ -34,7 +34,7 @@ var defaultOptions = options{
 	jitter:  100 * time.Millisecond,
 }
 
-// Wait executes the check using the supplied options
+// Wait executes the check using the supplied options.
 // Checks are retried until successful execution or option limits are reached.
 func Wait(c Check, opts ...Option) error {
 	if c == nil {
@@ -79,7 +79,7 @@ func Wait(c Check, opts ...Option) error {
 	}
 }
 
-// WithContext uses the supplied context for check execution
+// WithContext uses the supplied context for check execution.
 // This allows alternative context cancellations to be specified.
 func WithContext(ctx context.Context) Option {
 	return func(o *options) {
@@ -87,7 +87,7 @@ func WithContext(ctx context.Context) Option {
 	}
 }
 
-// WithTimeout specifies the retry execution timeout
+// WithTimeout specifies the retry execution timeout.
 // Retry execution will be cancelled either on the cancellation of a
 // supplied context or after the timeout has elapsed.
 // The default value is 30 seconds.
@@ -97,7 +97,7 @@ func WithTimeout(t time.Duration) Option {
 	}
 }
 
-// WithDelay specifies the retry delay between check executions
+// WithDelay specifies the retry delay between check executions.
 // The default value is one second.
 func WithDelay(d time.Duration) Option {
 	return func(o *options) {
@@ -105,7 +105,7 @@ func WithDelay(d time.Duration) Option {
 	}
 }
 
-// WithJitter specifies an optional maximum jitter to apply to the delay
+// WithJitter specifies an optional maximum jitter to apply to the delay.
 // The default value is 100 milliseconds.
 func WithJitter(j time.Duration) Option {
 	return func(o *options) {
@@ -113,7 +113,7 @@ func WithJitter(j time.Duration) Option {
 	}
 }
 
-// WithCallback specifies the callback function to be invoked after check execution
+// WithCallback specifies the callback function to be invoked after check execution.
 func WithCallback(fn CallbackFunc) Option {
 	return func(o *options) {
 		o.callback = fn

--- a/healthy.go
+++ b/healthy.go
@@ -78,6 +78,15 @@ func Wait(c Check, opts ...Option) error {
 	}
 }
 
+// JoinOptions joins the specified options to simplify re-use.
+func JoinOptions(opts ...Option) Option {
+	return func(o *options) {
+		for _, opt := range opts {
+			opt(o)
+		}
+	}
+}
+
 // WithContext uses the supplied context for check execution.
 // This allows alternative context cancellations to be specified.
 func WithContext(ctx context.Context) Option {

--- a/healthy.go
+++ b/healthy.go
@@ -114,7 +114,7 @@ func WithDelay(d time.Duration) Option {
 }
 
 // WithJitter specifies an optional maximum jitter to apply to the delay.
-// The default value is 100 milliseconds.
+// The default value is no jitter.
 func WithJitter(j time.Duration) Option {
 	return func(o *options) {
 		o.jitter = j

--- a/healthy.go
+++ b/healthy.go
@@ -31,7 +31,6 @@ const mdKeyAttempt = "attempt"
 var defaultOptions = options{
 	timeout: 30 * time.Second,
 	delay:   time.Second,
-	jitter:  100 * time.Millisecond,
 }
 
 // Wait executes the check using the supplied options.

--- a/metadata.go
+++ b/metadata.go
@@ -30,7 +30,7 @@ func WithMetadata(fn CheckFunc, pairs ...any) MetadataCheck {
 		panic("fn must not be nil")
 	}
 	if len(pairs)%2 != 0 {
-		panic("info must be key value pairs")
+		panic("metadata must be key value pairs")
 	}
 
 	c := &metadataCheck{

--- a/metadata.go
+++ b/metadata.go
@@ -5,7 +5,7 @@ import (
 )
 
 type (
-	// Metadata represents a check that has metadata
+	// Metadata represents a check that has metadata.
 	MetadataCheck interface {
 		Check
 		Metadata() Metadata
@@ -16,13 +16,13 @@ type (
 		fn CheckFunc
 	}
 
-	// Metadata represents check metadata
+	// Metadata represents check metadata.
 	Metadata map[string]any
 
 	metadataContextKey struct{}
 )
 
-// WithMetadata wraps the CheckFunc with the supplied metadata
+// WithMetadata wraps the [CheckFunc] with the supplied metadata.
 // Metadata should be specified in key/value pairs. The function will
 // panic if the pairs are invalid.
 func WithMetadata(fn CheckFunc, pairs ...any) MetadataCheck {
@@ -49,17 +49,17 @@ func WithMetadata(fn CheckFunc, pairs ...any) MetadataCheck {
 	return c
 }
 
-// Healthy returns nil if the health check is successful
+// Healthy returns nil if the health check is successful.
 func (c *metadataCheck) Healthy(ctx context.Context) error {
 	return c.fn(ctx)
 }
 
-// Metadata returns the check metadata
+// Metadata returns the check metadata.
 func (c *metadataCheck) Metadata() Metadata {
 	return c.md
 }
 
-// GetContextMetadata returns the metadata stored in the context
+// GetContextMetadata returns the [Metadata] stored in the .
 func GetContextMetadata(ctx context.Context) Metadata {
 	if m, ok := ctx.Value(metadataContextKey{}).(Metadata); ok {
 		return m
@@ -67,12 +67,12 @@ func GetContextMetadata(ctx context.Context) Metadata {
 	return Metadata{}
 }
 
-// SetContextMetadata stores the supplied metadata in the context
+// SetContextMetadata stores the supplied [Metadata] in the context.
 func SetContextMetadata(ctx context.Context, m Metadata) context.Context {
 	return context.WithValue(ctx, metadataContextKey{}, m)
 }
 
-// Set sets the metadata key/value
+// Set sets the metadata key/value.
 func (m Metadata) Set(key string, value any) {
 	if m == nil {
 		return
@@ -80,7 +80,7 @@ func (m Metadata) Set(key string, value any) {
 	m[key] = value
 }
 
-// Get gets the metadata value
+// Get gets the metadata value.
 func (m Metadata) Get(key string) any {
 	if m == nil {
 		return nil


### PR DESCRIPTION
This PR makes a number of relatively minor updates to the module:
* Add `JoinOptions` to simplify re-use when waiting on multiple checks
* Reduce default jitter to zero
* Correct `fatalError.Unwrap()` signature
* General documentation and test naming updates